### PR TITLE
Fix main entrypoint in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "highlight",
     "typescript"
   ],
-  "main": "dist/index.js",
+  "main": "dist/lib/index.js",
   "files": [
     "dist/lib"
   ],


### PR DESCRIPTION
Currently, `package.json` has `main` set to `dist/index.js` which doesn't exist. The entrypoint seems to be in`dist/lib/index.js`.